### PR TITLE
Added custom compilation function and related macros

### DIFF
--- a/addons/core/XEH_PREP.hpp
+++ b/addons/core/XEH_PREP.hpp
@@ -1,0 +1,3 @@
+FUNC(compileFunction) = compileFinal preprocessFileLineNumbers QPATHTOF(functions\DOUBLES(fnc,compileFunction).sqf);
+
+PREP(dumpCallstack);

--- a/addons/core/functions/fnc_compileFunction.sqf
+++ b/addons/core/functions/fnc_compileFunction.sqf
@@ -1,0 +1,54 @@
+/*
+ * Author: BaerMitUmlaut
+ * Compiles a function with the given function header and caches it.
+ *
+ * Arguments:
+ * 0: Function name                   <STRING>
+ * 1: Filepath                        <STRING>
+ * 2: Header filepath (default: none) <STRING>
+ * 3: Cache function (default: true)  <BOOL>
+ *
+ * Return Value:
+ * None
+ */
+#include "script_component.hpp"
+params [
+    ["_funcName", "", [""]],
+    ["_funcPath", "", [""]],
+    ["_headerPath", "", [""]],
+    ["_cache", false, [true]]
+];
+
+if (_funcName == "" || {_funcPath == ""}) exitWith {
+    ERROR_2("Cannot compile ""%1"" (%2): Invalid parameters.",_funcName,_funcPath);
+};
+
+if (isNil QGVAR(functionHeaders)) then {
+    GVAR(functionHeaders) = [[], ""] call CBA_fnc_hashCreate;
+};
+
+private _header = "";
+if (_headerPath != "") then {
+    _header = [GVAR(functionHeaders), _headerPath] call CBA_fnc_hashGet;
+    if (_header == "") then {
+        _header = preprocessFile _headerPath;
+        [GVAR(functionHeaders), _headerPath, _header] call CBA_fnc_hashSet;
+    };
+};
+
+private "_function";
+if (_cache) then {
+    _function = uiNamespace getVariable _funcName;
+    if (isNil "_function") then {
+        _function = preprocessFileLineNumbers _funcPath;
+        _function = format [_header, _funcName] + _function;
+        _function = compileFinal _function;
+        uiNamespace setVariable [_funcName, _function];
+    };
+} else {
+    _function = preprocessFileLineNumbers _funcPath;
+    _function = format [_header, _funcName] + _function;
+    _function = compile _function;
+};
+
+missionNamespace setVariable [_funcName, _function];

--- a/addons/core/functions/fnc_dumpCallstack.sqf
+++ b/addons/core/functions/fnc_dumpCallstack.sqf
@@ -1,0 +1,44 @@
+/*
+ * Author: BaerMitUmlaut
+ * Dumps the current callstack to the RPT.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ */
+#include "script_component.hpp"
+if (isNil QGVAR(callstack)) exitWith {};
+
+private _tab = "    ";
+private _nl = toString [13, 10];
+private _indentation = "";
+private _indentationMemory = [];
+_indentationMemory resize count GVAR(callstack);
+private _lastHandle = -1;
+
+private _output = "Dumping callstack:" + _nl;
+{
+    _x params ["_currentHandle", "_parent", "_parentHandle"];
+    private _current = GVAR(functionHandles) select _currentHandle;
+
+    if (_parentHandle != _lastHandle) then {
+        _indentation = _indentationMemory select _parentHandle;
+    };
+
+    if (_parent == (GVAR(functionHandles) param [_parentHandle, ""])) then {
+        _output = _output + _indentation + format ["-> %1", _current] + _nl;
+    } else {
+        if (_current == _parent) then {
+            _parent = "unknown function";
+        };
+        _output = _output + _indentation + format ["-> %1 (via %2)", _current, _parent] + _nl;
+    };
+
+    _indentation = _indentation + _tab;
+    _indentationMemory set [_currentHandle, _indentation];
+} forEach GVAR(callstack);
+
+LOG(_output);
+RETURN;

--- a/addons/core/script_header_api.hpp
+++ b/addons/core/script_header_api.hpp
@@ -1,0 +1,5 @@
+if (canSuspend) exitWith {
+    [%1, _this] call CBA_fnc_directCall;
+};
+
+#include "script_header_default.hpp"

--- a/addons/core/script_header_debug.hpp
+++ b/addons/core/script_header_debug.hpp
@@ -1,0 +1,16 @@
+#include "script_header_default.hpp"
+
+private _Soil_lastHandle = _Soil_functionHandle;
+private _Soil_functionHandle = Soil_core_functionHandles pushBack _fnc_scriptName;
+
+if (isNil "_Soil_lastHandle") then {
+    Soil_core_functionHandles = [_fnc_scriptName];
+    _Soil_functionHandle = 0;
+    Soil_core_callstack = [[_Soil_functionHandle, _fnc_scriptNameParent, -1]];
+} else {
+    Soil_core_callstack pushBack [_Soil_functionHandle, _fnc_scriptNameParent, _Soil_lastHandle];
+};
+
+if (canSuspend) then {
+    diag_log text "Warning: %1 was called in the scheduled environment.";
+};

--- a/addons/core/script_header_default.hpp
+++ b/addons/core/script_header_default.hpp
@@ -1,0 +1,3 @@
+scopeName "SOIL_ROOT_SCOPE";
+private _fnc_scriptNameParent = if (isNil "_fnc_scriptName") then {"%1"} else {_fnc_scriptName};
+private _fnc_scriptName = "%1";

--- a/addons/core/script_macros.hpp
+++ b/addons/core/script_macros.hpp
@@ -1,9 +1,164 @@
 #include "\x\cba\addons\main\script_macros_common.hpp"
 
+// Overloaded array macro, only use for config!
+#define ARR(var1) \
+    [var1]
+#define ARR(var1,var2) \
+    [var1, var2]
+#define ARR(var1,var2,var3) \
+    [var1, var2, var3]
+#define ARR(var1,var2,var3,var4) \
+    [var1, var2, var3, var4]
+#define ARR(var1,var2,var3,var4,var5) \
+    [var1, var2, var3, var4, var5]
+#define ARR(var1,var2,var3,var4,var5,var6) \
+    [var1, var2, var3, var4, var5, var6]
+#define ARR(var1,var2,var3,var4,var5,var6,var7) \
+    [var1, var2, var3, var4, var5, var6, var7]
+#define ARR(var1,var2,var3,var4,var5,var6,var7,var8) \
+    [var1, var2, var3, var4, var5, var6, var7, var8]
+#define ARR(var1,var2,var3,var4,var5,var6,var7,var8,var9) \
+    [var1, var2, var3, var4, var5, var6, var7, var8, var9]
+#define ARR(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10) \
+    [var1, var2, var3, var4, var5, var6, var7, var8, var9, var10]
+
+// - Tweaked logging - TODO: Push this to UI system ---------------------------
+#define LOG(message) diag_log text (message)
+#define LOG_FORMAT(message) diag_log formatText message
+#define LOG_SYS(level,message) \
+    LOG_FORMAT(ARR_4('[Soil %1] %2: %3','COMPONENT_BEAUTIFIED',level,message))
+
+// Contrary to CBA, these macros contain the square brackets
+#define ARR_1(var1) \
+    [var1]
+#define ARR_2(var1,var2) \
+    [var1, var2]
+#define ARR_3(var1,var2,var3) \
+    [var1, var2, var3]
+#define ARR_4(var1,var2,var3,var4) \
+    [var1, var2, var3, var4]
+#define ARR_5(var1,var2,var3,var4,var5) \
+    [var1, var2, var3, var4, var5]
+#define ARR_6(var1,var2,var3,var4,var5,var6) \
+    [var1, var2, var3, var4, var5, var6]
+#define ARR_7(var1,var2,var3,var4,var5,var6,var7) \
+    [var1, var2, var3, var4, var5, var6, var7]
+#define ARR_8(var1,var2,var3,var4,var5,var6,var7,var8) \
+    [var1, var2, var3, var4, var5, var6, var7, var8]
+#define ARR_9(var1,var2,var3,var4,var5,var6,var7,var8,var9) \
+    [var1, var2, var3, var4, var5, var6, var7, var8, var9]
+#define ARR_10(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10) \
+    [var1, var2, var3, var4, var5, var6, var7, var8, var9, var10]
+
+#define INFO(var1) \
+    LOG_SYS("Info",var1)
+#define INFO_1(var1,var2) \
+    INFO(format ARR_2(var1,var2))
+#define INFO_2(var1,var2,var3) \
+    INFO(format ARR_3(var1,var2,var3))
+#define INFO_3(var1,var2,var3,var4) \
+    INFO(format ARR_4(var1,var2,var3,var4))
+#define INFO_4(var1,var2,var3,var4,var5) \
+    INFO(format ARR_5(var1,var2,var3,var4,var5))
+#define INFO_5(var1,var2,var3,var4,var5,var6) \
+    INFO(format ARR_6(var1,var2,var3,var4,var5,var6))
+#define INFO_6(var1,var2,var3,var4,var5,var6,var7) \
+    INFO(format ARR_7(var1,var2,var3,var4,var5,var6,var7))
+#define INFO_7(var1,var2,var3,var4,var5,var6,var7,var8) \
+    INFO(format ARR_8(var1,var2,var3,var4,var5,var6,var7,var8))
+#define INFO_8(var1,var2,var3,var4,var5,var6,var7,var8,var9) \
+    INFO(format ARR_9(var1,var2,var3,var4,var5,var6,var7,var8,var9))
+#define INFO_9(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10) \
+    INFO(format ARR_10(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10))
+
+#define WARNING(var1) \
+    LOG_SYS("Warning",var1)
+#define WARNING_1(var1,var2) \
+    WARNING(format ARR_2(var1,var2))
+#define WARNING_2(var1,var2,var3) \
+    WARNING(format ARR_3(var1,var2,var3))
+#define WARNING_3(var1,var2,var3,var4) \
+    WARNING(format ARR_4(var1,var2,var3,var4))
+#define WARNING_4(var1,var2,var3,var4,var5) \
+    WARNING(format ARR_5(var1,var2,var3,var4,var5))
+#define WARNING_5(var1,var2,var3,var4,var5,var6) \
+    WARNING(format ARR_6(var1,var2,var3,var4,var5,var6))
+#define WARNING_6(var1,var2,var3,var4,var5,var6,var7) \
+    WARNING(format ARR_7(var1,var2,var3,var4,var5,var6,var7))
+#define WARNING_7(var1,var2,var3,var4,var5,var6,var7,var8) \
+    WARNING(format ARR_8(var1,var2,var3,var4,var5,var6,var7,var8))
+#define WARNING_8(var1,var2,var3,var4,var5,var6,var7,var8,var9) \
+    WARNING(format ARR_9(var1,var2,var3,var4,var5,var6,var7,var8,var9))
+#define WARNING_9(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10) \
+    WARNING(format ARR_10(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10))
+
+#define ERROR(var1) \
+    LOG_SYS("Error",var1)
+#define ERROR_1(var1,var2) \
+    ERROR(format ARR_2(var1,var2))
+#define ERROR_2(var1,var2,var3) \
+    ERROR(format ARR_3(var1,var2,var3))
+#define ERROR_3(var1,var2,var3,var4) \
+    ERROR(format ARR_4(var1,var2,var3,var4))
+#define ERROR_4(var1,var2,var3,var4,var5) \
+    ERROR(format ARR_5(var1,var2,var3,var4,var5))
+#define ERROR_5(var1,var2,var3,var4,var5,var6) \
+    ERROR(format ARR_6(var1,var2,var3,var4,var5,var6))
+#define ERROR_6(var1,var2,var3,var4,var5,var6,var7) \
+    ERROR(format ARR_7(var1,var2,var3,var4,var5,var6,var7))
+#define ERROR_7(var1,var2,var3,var4,var5,var6,var7,var8) \
+    ERROR(format ARR_8(var1,var2,var3,var4,var5,var6,var7,var8))
+#define ERROR_8(var1,var2,var3,var4,var5,var6,var7,var8,var9) \
+    ERROR(format ARR_9(var1,var2,var3,var4,var5,var6,var7,var8,var9))
+#define ERROR_9(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10) \
+    ERROR(format ARR_10(var1,var2,var3,var4,var5,var6,var7,var8,var9,var10))
+
+// - Custom compilation related macros ----------------------------------------
+#ifndef FUNCTION_HEADER
+    #define FUNCTION_HEADER QPATHTOEF(core,script_header_default.hpp)
+#endif
+
+#ifdef DEBUG_MODE_FULL
+    #define FUNCTION_HEADER QPATHTOEF(core,script_header_debug.hpp)
+#endif
+
 #ifdef DISABLE_COMPILE_CACHE
-    #undef PREP
-    #define PREP(fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(functions\DOUBLES(fnc,fncName).sqf)
+    #define ENABLE_CACHING false
 #else
-    #undef PREP
-    #define PREP(fncName) [QPATHTOF(functions\DOUBLES(fnc,fncName).sqf), QFUNC(fncName)] call CBA_fnc_compileFunction
+    #define ENABLE_CACHING true
+#endif
+
+#define PREP(funcName) \
+    [ \
+        QFUNC(funcName), \
+        QPATHTOF(functions\DOUBLES(fnc,funcName).sqf), \
+        FUNCTION_HEADER, \
+        ENABLE_CACHING \
+    ] call EFUNC(core,compileFunction)
+#define PREP_NOHEAD(funcName) \
+    [ \
+        QFUNC(funcName), \
+        QPATHTOF(functions\DOUBLES(fnc,funcName).sqf), \
+        "", \
+        ENABLE_CACHING \
+    ] call EFUNC(core,compileFunction)
+
+#define RETURN breakOut "SOIL_ROOT_SCOPE"
+#ifdef DEBUG_MODE_FULL
+    #define RETURNV(value) \
+        private _ret = value; \
+        if (isNil "_ret") then { \
+            breakOut "SOIL_ROOT_SCOPE"; \
+        } else { \
+            _ret breakOut "SOIL_ROOT_SCOPE"; \
+        }
+#else
+    #define RETURNV(value) \
+        private _ret = value; \
+        if (isNil "_ret") then { \
+            WARNING_1("%1 returned nil value.",_fnc_scriptName); \
+            breakOut "SOIL_ROOT_SCOPE"; \
+        } else { \
+            _ret breakOut "SOIL_ROOT_SCOPE"; \
+        }
 #endif


### PR DESCRIPTION
**When merged this pull request will:**
- Add a custom compile function with caching, similar to the CBA one, but with the addition to automatically add function headers (based upon https://github.com/CBATeam/CBA_A3/pull/538)
- Add and redefine a bunch of macros

This PR will allow us to use a `RETURN` and `RETURNV(value)` macro and do some nice callstack logging which should be nice. I've also added a header we can later use in the API to ensure unscheduled execution.

There is also a new overloaded `ARR` macro which we can use in config (armake allows macro overloading).